### PR TITLE
closes #39

### DIFF
--- a/R/AuxiliaryFunctions.R
+++ b/R/AuxiliaryFunctions.R
@@ -320,3 +320,38 @@ extract_indicators <- function(bgms_object) {
                 "edge_selection = TRUE and save = TRUE."))
   }
 }
+
+# This function returns cluster colors for plots
+# input: cluster allocations (null or numeric vector)
+# output: a vector of colors for each vertex
+get_cluster_colors <- function(cluster_allocations) {
+  random_hcl <- function(n,
+                         c_range = c(55, 80),   
+                         l_range = c(45, 75)) { 
+    h <- runif(n, 0, 360)                     
+    c <- runif(n, c_range[1], c_range[2])
+    l <- runif(n, l_range[1], l_range[2])
+    hcl(h, c, l)
+  }
+  
+  
+  if (!all(is.na(cluster_allocations)) && length(unique(cluster_allocations)) > 1) {
+    n <- length(unique(cluster_allocations))
+    
+    # OkabeIto is a color blind palette, it works with up to 9 colors
+    if (n <= 9) {
+      colors <- palette.colors(n, "OkabeIto")
+      
+    } else {
+      # This supports the (uncommon) cases with 10+ clusters
+      colors <- random_hcl(n)  
+    }
+    
+    return( sapply(cluster_allocations, function(X) colors[X]))
+    
+  } else {
+    return(c())
+  }
+  
+}
+

--- a/R/plottingfunctions.easybgm.R
+++ b/R/plottingfunctions.easybgm.R
@@ -1,37 +1,3 @@
-#' @keywords internal
-get_cluster_colors <- function(easybgm_object) {
-  random_hcl <- function(n,
-                         c_range = c(55, 80),   
-                         l_range = c(45, 75)) { 
-    h <- runif(n, 0, 360)                     
-    c <- runif(n, c_range[1], c_range[2])
-    l <- runif(n, l_range[1], l_range[2])
-    hcl(h, c, l)
-  }
-  
-  
-  if (!all(is.na(easybgm_object$cluster_allocations)) && length(unique(easybgm_object$cluster_allocations)) > 1) {
-    n <- length(unique(easybgm_object$cluster_allocations))
-    
-    # OkabeIto is a color blind palette, it works with up to 9 colors
-    if (n <= 9) {
-      colors <- palette.colors(n, "OkabeIto")
-      
-    } else {
-      # This supports the (uncommon) cases with 10+ clusters
-      colors <- random_hcl(n)  
-    }
-    
-    return( sapply(easybgm_object$cluster_allocations, function(X) colors[X]))
-    
-  } else {
-    return(c())
-  }
-  
-}
-
-
-# ---------------------------------------------------------------------------
 #' @export
 plot_structure_probabilities.easybgm <- function(output, as_BF = FALSE, ...) {
   if(!any(class(output) == "easybgm")){
@@ -200,7 +166,7 @@ plot_edgeevidence.easybgm <- function(output, evidence_thresh = 10, split = FALS
                          graph_color <- args$colors[3], graph_color <- args$colors[1])
   graph_color[graph < (1/evidence_thresh)] <- args$colors[2]
   
-  cluster_color <- get_cluster_colors(output)
+  cluster_color <- get_cluster_colors(output$cluster_allocations)
   
   if (show == "all") {
     if (!split) {
@@ -304,7 +270,6 @@ plot_edgeevidence.easybgm <- function(output, evidence_thresh = 10, split = FALS
 
 #' @export
 plot_network.easybgm <- function(output, exc_prob = 0.5, evidence_thresh = 10,  dashed = FALSE, ...) {
-  
   if(!any(class(output) == "easybgm")){
     stop("Wrong input provided. The function requires as input the output of the easybgm function.")
   }
@@ -338,7 +303,7 @@ plot_network.easybgm <- function(output, exc_prob = 0.5, evidence_thresh = 10,  
   diag(graph) <- 1
   
   
-  cluster_colors <- get_cluster_colors(output)
+  cluster_colors <- get_cluster_colors(output$cluster_allocations)
   # Plot
   if(dashed){
     graph_dashed <- ifelse(output$inc_BF < args$evidence_thresh, 2, 1)


### PR DESCRIPTION
code to check the cluster coloring:
devtools::load_all()

simulate_easybgm <- function(n_obs     = 300,
                             clusters  = c(6, 6),   # sizes of each block
                             r_within  = 0.60,       # within‑cluster ρ
                             r_between = 0.10,       # between‑cluster ρ
                             likert    = 5,          # 1:likert ordinal scale
                             iter      = 1000) {
  
  p  <- sum(clusters)                      # total number of variables
  Sigma <- matrix(r_between, p, p)         # start with between‑cluster corr
  offset <- 1
  for (sz in clusters) {                   # fill each diagonal block
    idx <- seq(offset, length.out = sz)
    Sigma[idx, idx] <- r_within
    offset <- offset + sz
  }
  diag(Sigma) <- 1
  
  # ---- simulate ordinal data -----------------------------------------------
  raw <- MASS::mvrnorm(n_obs, mu = rep(0, p), Sigma = Sigma)
  data <- apply(raw, 2, function(col) {
    cut(col,
        breaks = quantile(col, probs = seq(0, 1, length.out = likert + 1)),
        include.lowest = TRUE,
        labels = FALSE)
  })
  data <- as.data.frame(data)
  names(data) <- paste0("Item", seq_len(p))
  
  # ---- fit easybgm ----------------------------------------------------------
  easybgm(data,
          type       = "ordinal",
          edge_prior = "Stochastic-Block",
          iter       = iter)
}
tests <- list(
  list(name = "baseline",
       clusters = c(6, 6),
       edge_split   = FALSE,
       edge_show    = "all",
       net_dashed   = FALSE),

  list(name = "edge_split",
       clusters = c(6, 6),
       edge_split   = TRUE,
       edge_show    = "all",
       net_dashed   = FALSE),
  
  list(name = "edge_included",
       clusters = c(6, 6),
       edge_split   = FALSE,
       edge_show    = "included",
       net_dashed   = FALSE),
  
  list(name = "edge_excluded",
       clusters = c(6, 6),
       edge_split   = FALSE,
       edge_show    = "excluded",
       net_dashed   = FALSE),
  
  list(name = "edge_inconclusive",
       clusters = c(6, 6),
       edge_split   = FALSE,
       edge_show    = "inconclusive",
       net_dashed   = FALSE),
  
  list(name = "network_dashed",
       clusters = c(6, 6),
       edge_split   = FALSE,
       edge_show    = "all",
       net_dashed   = TRUE))
  

################################################################################
# Run the tests ------------------------------------------------------------
################################################################################
for (spec in tests) {
  
  message("\n==============  ", toupper(spec$name), "  ==============")
  fit  <- simulate_easybgm(clusters  = spec$clusters)
  
  
  # ---- plot_edgeevidence ----------------------------------------------------
  plot_edgeevidence(
    fit,
    split = spec$edge_split,
    show  = spec$edge_show,
    color = cols,
    main  = paste("Edge evidence –", spec$name)
  )
  
  Sys.sleep(5)
  # ---- plot_network ---------------------------------------------------------
  plot_network(
    fit,
    dashed = spec$net_dashed,
    color  = cols,
    main   = paste("Network –", spec$name)
  )
  Sys.sleep(5)
}


#######################
# try k clusters
#######################
# ---------------------------------------------------------------------------
# simulate_cluster_data()
# ---------------------------------------------------------------------------
# n_obs        : number of cases
# n_clusters   : how many distinct latent blocks you want
# cluster_size : either a single integer (equal size) or a vector of lengths
# r_within     : correlation inside each block
# r_between    : correlation between blocks
# likert       : number of ordinal levels (set to 0 to keep it continuous)
#
# Returns a list with:
#   $data        data‑frame ready for easybgm()
#   $allocations vector of true cluster labels (one per variable)

simulate_cluster_data <- function(n_obs       = 300,
                                  n_clusters  = 3,
                                  cluster_size = 4,
                                  r_within    = 0.80,
                                  r_between   = 0.05,
                                  likert      = 5) {
  
  # --- handle cluster sizes --------------------------------------------------
  if (length(cluster_size) == 1)
    cluster_size <- rep(cluster_size, n_clusters)
  stopifnot(length(cluster_size) == n_clusters)
  
  p <- sum(cluster_size)              # total variables
  Sigma <- matrix(r_between, p, p)    # start with between‑cluster corr
  
  offset <- 1
  allocations <- integer(p)
  for (k in seq_len(n_clusters)) {
    idx <- seq(offset, length.out = cluster_size[k])
    Sigma[idx, idx] <- r_within
    allocations[idx] <- k
    offset <- offset + cluster_size[k]
  }
  diag(Sigma) <- 1                    # positive‑definite correlation matrix
  
  # --- simulate data --------------------------------------------------------
  X <- MASS::mvrnorm(n_obs, mu = rep(0, p), Sigma = Sigma)
  
  if (likert > 0) {
    X <- apply(X, 2, function(col) {
      cut(col,
          breaks = quantile(col, probs = seq(0, 1, length.out = likert + 1)),
          include.lowest = TRUE,
          labels = FALSE)
    })
  }
  
  dat <- as.data.frame(X)
  names(dat) <- paste0("Item", seq_len(p))
  
  list(data = dat, allocations = allocations)
}


test_K <- c(1, 2, 3, 5, 10)           # cluster counts to try

for (k in test_K) {
  
  cat("\n###", k, "clusters ###\n")
  sim <- simulate_cluster_data(n_clusters = k,
                               cluster_size = 4,     # 4 items per cluster
                               r_within = 0.9,       # strong signal
                               r_between = 0.02,     # weak cross‑links
                               likert = 5)
  
  fit <- easybgm(sim$data,
                 type       = "ordinal",
                 edge_prior = "Stochastic-Block",
                 iter       = 2000)
  
  # overwrite with ground‑truth labels so plotting sees all k clusters
  fit$cluster_allocations <- sim$allocations
  
  # colour helper (unchanged)
  cols <- {
    kunique <- length(unique(fit$cluster_allocations))
    pal <- if (kunique <= 9) palette.colors(kunique, "OkabeIto")
    else grDevices::rainbow(kunique)
    pal[fit$cluster_allocations]
  }
  
  plot_edgeevidence(fit, color = cols,
                    main = paste("Edge evidence –", k, "clusters"))
  Sys.sleep(5)
  plot_network(fit, color = cols,
               main = paste("Network –", k, "clusters"))
  Sys.sleep(5)
}
